### PR TITLE
Fix version restriction of recursion-schemes

### DIFF
--- a/egison-pattern-src/egison-pattern-src.cabal
+++ b/egison-pattern-src/egison-pattern-src.cabal
@@ -38,7 +38,7 @@ library
     , mtl                 ^>=2.2.1
     , parser-combinators  >=1.0.0 && <1.3
     , prettyprinter       >=1.0.0
-    , recursion-schemes   >=5.2
+    , recursion-schemes   >=5.0.2
     , text                >=0.1.0 && <1.3
 
   hs-source-dirs:     src


### PR DESCRIPTION
Commit f47fdeb4c36888d9213e9c55ac78970ca6a1c933 changed the version restriction on recursion-schemes from `>=5.0.2 && <5.2` to `>=5.2`, but it should've been `>=5.0.2`.